### PR TITLE
Fix installation & default settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# SQLite3 database
+db.sqlite3

--- a/KALanguageReport/settings.default
+++ b/KALanguageReport/settings.default
@@ -60,8 +60,8 @@ WSGI_APPLICATION = 'KALanguageReport.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': '',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'db.sqlite3',
         'USER': '',
         'PASSWORD': ''
     }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@ Especially reaching 100% does in no way mean that Khan Academy will upgrade your
 ## Installation
   1. Install Python 2.7
   2. Install Django 1.7
-  3. get code from github
-  4. copy the file KALanguageReport/settings.default to settings.py and adapt the DB and last 3 values 
+  3. Clone git repository: `git clone https://github.com/alani1/KALanguageReport.git`
+  4. copy the file `KALanguageReport/settings.default` to `settings.py` and adapt the DB and last 3 values
+
+
+## Install python dependencies
+
+```bash
+sudo pip install -r requirements.txt
+```
+
 
 ## Enhancement Ideas and TODOs
 - [ ] Add awesome charts with dynamic date selection etc.
@@ -18,9 +26,9 @@ Especially reaching 100% does in no way mean that Khan Academy will upgrade your
 ## Commands to be used on the commandline
 
 To start the development server use:
-`python manage.py runserver 37.221.195.59:8008
+```python manage.py runserver 37.221.195.59:8008```
 
-`python manage.py loadMasterlist`
+```python manage.py loadMasterlist```
 Should be run every Month once the new Masterlist is out. First update with new DocumentID
 
 `python manage.py updateAmaraMapping`
@@ -31,11 +39,6 @@ download amara subtitle information, this process takes very long
 
 `python manage.py KALangStatistic LANGUAGE`
 generate the report files for specific LANGUAGE. Make sure the LANGUAGE is defined in the database
-
-## Python prerequirements to be installed
-
-pip install jsonfield
-pip install django-import-export
 
 ## License information:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Especially reaching 100% does in no way mean that Khan Academy will upgrade your
 ## Commands to be used on the commandline
 
 To start the development server use:
-```python manage.py runserver 37.221.195.59:8008```
+```python manage.py runserver 0.0.0.0:8008```
 
 ```python manage.py loadMasterlist```
 Should be run every Month once the new Masterlist is out. First update with new DocumentID

--- a/README.md
+++ b/README.md
@@ -5,17 +5,10 @@ KALanguageReport is a tool of the KA Deutsch Community and is not officially aff
 Especially reaching 100% does in no way mean that Khan Academy will upgrade your language to the next stage. But could be a strong indicator that you are getting ready for this.
 
 ## Installation
-  1. Install Python 2.7
-  2. Install Django 1.7
+  1. Install Python 2.7 and `pip` (e.g. `sudo easy_install pip`)
+  2. `sudo pip install -r requirements.txt`
   3. Clone git repository: `git clone https://github.com/alani1/KALanguageReport.git`
   4. Copy default configuration: `cp KALanguageReport/settings.default settings.py` and adapt the DB and last 3 values
-
-
-## Install python dependencies
-
-```bash
-sudo pip install -r requirements.txt
-```
 
 
 ## Enhancement Ideas and TODOs

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Especially reaching 100% does in no way mean that Khan Academy will upgrade your
   1. Install Python 2.7 and `pip` (e.g. `sudo easy_install pip`)
   2. `sudo pip install -r requirements.txt`
   3. Clone git repository: `git clone https://github.com/alani1/KALanguageReport.git`
-  4. Copy default configuration: `cp KALanguageReport/settings.default settings.py` and adapt the DB and last 3 values
+  4. Copy default configuration: `cp KALanguageReport/settings.default KALanguageReport/settings.py` and adapt the DB and last 3 values
 
 
 ## Enhancement Ideas and TODOs
@@ -19,7 +19,7 @@ Especially reaching 100% does in no way mean that Khan Academy will upgrade your
 ## Commands to be used on the commandline
 
 To start the development server use:
-```python manage.py runserver 0.0.0.0:8008```
+```python manage.py runserver 0.0.0.0   :8008```
 
 ```python manage.py loadMasterlist```
 Should be run every Month once the new Masterlist is out. First update with new DocumentID

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If desired, replace `de` by your language in step 4.
 ## Commands to be used on the commandline
 
 To start the development server use:
-```python manage.py runserver 0.0.0.0   :8008```
+```python manage.py runserver 0.0.0.0:8008```
 
 ```python manage.py loadMasterlist```
 Should be run every Month once the new Masterlist is out. First update with new DocumentID

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Especially reaching 100% does in no way mean that Khan Academy will upgrade your
   1. Install Python 2.7
   2. Install Django 1.7
   3. Clone git repository: `git clone https://github.com/alani1/KALanguageReport.git`
-  4. copy the file `KALanguageReport/settings.default` to `settings.py` and adapt the DB and last 3 values
+  4. Copy default configuration: `cp KALanguageReport/settings.default settings.py` and adapt the DB and last 3 values
 
 
 ## Install python dependencies

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ Especially reaching 100% does in no way mean that Khan Academy will upgrade your
   1. Install Python 2.7 and `pip` (e.g. `sudo easy_install pip`)
   2. `sudo pip install -r requirements.txt`
   3. Clone git repository: `git clone https://github.com/alani1/KALanguageReport.git`
-  4. Copy default configuration: `cp KALanguageReport/settings.default KALanguageReport/settings.py` and adapt the DB and last 3 values
+  4. Copy default configuration: `cp KALanguageReport/settings.default KALanguageReport/settings.py`
+  5. Create database: `python manage.py syncdb`
+
+Now you're ready for the initial data import:
+  1. `python manage.py loadMasterList`
+  2. `python manage.py upateAmaraMapping`
+  3. `python manage.py updateSubtitles`
+  4. `python manage.py KALangStatistics de`
+
+If desired, replace `de` by your language in step 4.
 
 
 ## Enhancement Ideas and TODOs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+jsonfield
+django
+django-import-export


### PR DESCRIPTION
Set default database type to SQLite3.
Fix installation documentation and use pip `requirements.txt` instead of distinct commands to install both django and other dependencies.
